### PR TITLE
feat: Initialize Go project structure

### DIFF
--- a/eph/.gitignore
+++ b/eph/.gitignore
@@ -1,0 +1,35 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Code coverage profiles and other test artifacts
+*.out
+coverage.*
+*.coverprofile
+profile.cov
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# env file
+.env
+
+# Editor/IDE
+# .idea/
+# .vscode/
+
+# Binaries
+bin/

--- a/eph/Makefile
+++ b/eph/Makefile
@@ -1,0 +1,20 @@
+.PHONY: build test clean
+
+VERSION := $(shell git describe --tags --always --dirty)
+LDFLAGS := -ldflags "-X github.com/ephlabs/eph/pkg/version.Version=$(VERSION)"
+
+build:
+	go build $(LDFLAGS) -o bin/eph ./cmd/eph
+	go build $(LDFLAGS) -o bin/ephd ./cmd/ephd
+
+test:
+	go test ./... -v -cover
+
+clean:
+	rm -rf bin/
+
+run-daemon:
+	go run ./cmd/ephd
+
+run-cli:
+	go run ./cmd/eph

--- a/eph/README.md
+++ b/eph/README.md
@@ -1,0 +1,11 @@
+# Eph Project
+
+Eph is a tool for managing ephemeral environments.
+
+## Building
+To build the Eph CLI and daemon, run:
+```bash
+make build
+```
+
+This will produce `bin/eph` and `bin/ephd`.

--- a/eph/cmd/eph/main.go
+++ b/eph/cmd/eph/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Println("Eph CLI - What the eph?")
+	os.Exit(0)
+}

--- a/eph/cmd/ephd/main.go
+++ b/eph/cmd/ephd/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Println("Eph Daemon - Starting ephemeral environment controller")
+	os.Exit(0)
+}

--- a/eph/configs/README.md
+++ b/eph/configs/README.md
@@ -1,0 +1,3 @@
+# Placeholder
+
+This directory will be used for example configurations.

--- a/eph/docs/README.md
+++ b/eph/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+This directory will contain architecture diagrams, setup guides, and other documentation for Eph.

--- a/eph/internal/migrate/README.md
+++ b/eph/internal/migrate/README.md
@@ -1,0 +1,3 @@
+# Placeholder
+
+This directory will be used for database migration logic.

--- a/eph/migrations/README.md
+++ b/eph/migrations/README.md
@@ -1,0 +1,3 @@
+# Placeholder
+
+This directory will be used for database migrations.

--- a/eph/pkg/api/README.md
+++ b/eph/pkg/api/README.md
@@ -1,0 +1,9 @@
+# API Package
+
+This package will contain HTTP API handlers for the Eph daemon.
+
+Future contents:
+- Webhook handlers for GitHub events
+- REST API endpoints for environment management
+- Authentication middleware
+- OpenAPI/Swagger definitions

--- a/eph/pkg/config/README.md
+++ b/eph/pkg/config/README.md
@@ -1,0 +1,3 @@
+# Placeholder
+
+This directory will be used for configuration parsing.

--- a/eph/pkg/controller/README.md
+++ b/eph/pkg/controller/README.md
@@ -1,0 +1,9 @@
+# Controller Package
+
+This package will contain the core environment orchestration logic.
+
+Future contents:
+- Environment lifecycle management
+- Provider coordination
+- State machine for environment status
+- Resource cleanup logic

--- a/eph/pkg/log/README.md
+++ b/eph/pkg/log/README.md
@@ -1,0 +1,3 @@
+# Placeholder
+
+This directory will be used for structured logging.

--- a/eph/pkg/providers/README.md
+++ b/eph/pkg/providers/README.md
@@ -1,0 +1,3 @@
+# Placeholder
+
+This directory will be used for provider implementations.

--- a/eph/pkg/providers/kubernetes/README.md
+++ b/eph/pkg/providers/kubernetes/README.md
@@ -1,0 +1,9 @@
+# Kubernetes Provider
+
+Built-in provider for creating ephemeral environments in Kubernetes.
+
+Future contents:
+- Namespace creation and management
+- Manifest application (raw YAML and Kustomize)
+- Service/Ingress configuration
+- Resource monitoring and cleanup

--- a/eph/pkg/state/README.md
+++ b/eph/pkg/state/README.md
@@ -1,0 +1,3 @@
+# Placeholder
+
+This directory will be used for PostgreSQL state management.

--- a/eph/pkg/version/README.md
+++ b/eph/pkg/version/README.md
@@ -1,0 +1,3 @@
+# Placeholder
+
+This directory will be used for version information.

--- a/eph/pkg/webhook/README.md
+++ b/eph/pkg/webhook/README.md
@@ -1,0 +1,3 @@
+# Placeholder
+
+This directory will be used for Git webhook handlers.

--- a/eph/pkg/worker/README.md
+++ b/eph/pkg/worker/README.md
@@ -1,0 +1,3 @@
+# Placeholder
+
+This directory will be used for background job processing.

--- a/eph/scripts/README.md
+++ b/eph/scripts/README.md
@@ -1,0 +1,3 @@
+# Placeholder
+
+This directory will be used for build and utility scripts.

--- a/eph/web/README.md
+++ b/eph/web/README.md
@@ -1,0 +1,11 @@
+# Eph Web Dashboard
+
+React-based web interface for Eph.
+
+Future contents:
+- Environment listing and status
+- Log viewing
+- Manual environment controls
+- Authentication and user management
+
+This will be implemented after the core MVP functionality is working.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ephlabs/eph
+
+go 1.22.2


### PR DESCRIPTION
This commit establishes the initial Go project structure for Eph, including the module setup, directory layout, basic Makefile, .gitignore, and placeholder main.go and README.md files.

The directory structure follows the Standard Go Project Layout. The Makefile includes targets for building the CLI and daemon, running tests, and cleaning the build artifacts.

Placeholder main.go files for cmd/eph and cmd/ephd print startup messages. Placeholder README files have been added to all planned directories, outlining their future purpose.

The .gitignore is based on the standard GitHub Go template with an additional entry for the local bin/ directory.

Verification included:
- `make build` successfully creates `bin/eph` and `bin/ephd`.
- Running `bin/eph` prints "Eph CLI - What the eph?".
- Running `bin/ephd` prints "Eph Daemon - Starting ephemeral environment controller".

Resolves #1 