### PR TITLE
EPH-28: add basic YAML file reading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v2.4
           args: --timeout=5m
 
       - name: Check go mod tidy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.4
           args: --timeout=5m

--- a/.golangci.bck.yml
+++ b/.golangci.bck.yml
@@ -1,0 +1,19 @@
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  enable:
+    - bodyclose
+    - gocritic
+    - goimports
+    - gosec
+    - misspell
+    - revive
+    - unconvert
+    - unparam
+    - whitespace
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,19 +1,39 @@
+version: "2"
 run:
   timeout: 5m
   tests: true
-
+  skip-dirs:
+    - "testdata"
 linters:
   enable:
     - bodyclose
     - gocritic
-    - goimports
     - gosec
     - misspell
     - revive
     - unconvert
     - unparam
     - whitespace
-
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,8 +2,6 @@ version: "2"
 run:
   timeout: 5m
   tests: true
-  skip-dirs:
-    - "testdata"
 linters:
   enable:
     - bodyclose
@@ -25,6 +23,7 @@ linters:
       - third_party$
       - builtin$
       - examples$
+      - testdata$
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
@@ -37,3 +36,4 @@ formatters:
       - third_party$
       - builtin$
       - examples$
+      - testdata$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,5 +17,6 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        exclude: ^.*testdata/.*\.ya?ml$
       - id: check-added-large-files
       - id: check-merge-conflict

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -26,5 +27,4 @@ require (
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/config/testdata/comments_only.yaml
+++ b/internal/config/testdata/comments_only.yaml
@@ -1,0 +1,14 @@
+# name: TestData
+# version: 1.0
+# enabled: true
+# max_users: 100
+# features:
+#   authentication: true
+#   logging:
+#     level: info
+#     destinations:
+#       - file
+#       - console
+# database:
+#   host: localhost
+#   port: 1234

--- a/internal/config/testdata/invalid.yaml
+++ b/internal/config/testdata/invalid.yaml
@@ -1,0 +1,2 @@
+key: value
+another_key

--- a/internal/config/testdata/valid.yaml
+++ b/internal/config/testdata/valid.yaml
@@ -1,0 +1,14 @@
+name: TestData
+version: 1.0
+enabled: true
+max_users: 100
+features:
+  authentication: true
+  logging:
+    level: info
+    destinations:
+      - file
+      - console
+database:
+  host: localhost
+  port: 1234

--- a/internal/config/yaml_reader.go
+++ b/internal/config/yaml_reader.go
@@ -29,7 +29,7 @@ func readYAMLFile(path string) (any, error) {
 
 	// if the file is empty but syntactically valid, return an error
 	if out == nil {
-		return nil, errors.New("failed to parse yaml")
+		return nil, errors.New("yaml file contains no data (empty or comments-only)")
 	}
 
 	return out, nil

--- a/internal/config/yaml_reader.go
+++ b/internal/config/yaml_reader.go
@@ -31,7 +31,7 @@ func readYAMLFile(path string) (any, error) {
 	}
 
 	// Read file into memory
-	data, err := os.ReadFile(filePath)
+	data, err := os.ReadFile(filePath) /* #nosec G304 user input for filepath is ok for yaml config */
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/yaml_reader.go
+++ b/internal/config/yaml_reader.go
@@ -3,15 +3,35 @@ package config
 import (
 	"errors"
 	"os"
+	"path/filepath"
 
 	"gopkg.in/yaml.v3"
+)
+
+const defaultConfigFile = "eph.yaml"
+
+var (
+	// Feature flag: if false, the function will default to using ./eph.yaml
+	AllowCustomConfigPath = false
 )
 
 // readYAMLFile reads a YAML file at the given path
 // and unmarshals it into a generic map[string]interface{}.
 func readYAMLFile(path string) (any, error) {
+	var filePath string
+	if AllowCustomConfigPath && len(path) > 0 && path != "" {
+		filePath = path
+	} else {
+		// Default to toplevel `eph.yaml`
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+		filePath = filepath.Join(cwd, defaultConfigFile)
+	}
+
 	// Read file into memory
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/yaml_reader.go
+++ b/internal/config/yaml_reader.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"errors"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// readYAMLFile reads a YAML file at the given path
+// and unmarshals it into a generic map[string]interface{}.
+func readYAMLFile(path string) (any, error) {
+	// Read file into memory
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// if there is nothing to unmarshal, return an error
+	if len(data) == 0 {
+		return nil, errors.New("empty file")
+	}
+
+	// Unmarshal into a generic structure
+	var out any
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+
+	// if the file is empty but syntactically valid, return an error
+	if out == nil {
+		return nil, errors.New("failed to parse yaml")
+	}
+
+	return out, nil
+}

--- a/internal/config/yaml_reader_test.go
+++ b/internal/config/yaml_reader_test.go
@@ -34,7 +34,7 @@ func TestCanReadYAMLFile(t *testing.T) {
 	assert.Equal(t, "TestData", yamlMap["name"])
 	assert.Equal(t, 1.0, yamlMap["version"])
 	assert.Equal(t, true, yamlMap["enabled"])
-	assert.Equal(t, int(100), yamlMap["max_users"])
+	assert.Equal(t, 100, yamlMap["max_users"])
 
 	features := yamlMap["features"].(map[string]any)
 	assert.Equal(t, true, features["authentication"])
@@ -45,7 +45,7 @@ func TestCanReadYAMLFile(t *testing.T) {
 
 	database := yamlMap["database"].(map[string]any)
 	assert.Equal(t, "localhost", database["host"])
-	assert.Equal(t, int(1234), database["port"])
+	assert.Equal(t, 1234, database["port"])
 }
 
 // also handles when given a path to a dir rather than a file

--- a/internal/config/yaml_reader_test.go
+++ b/internal/config/yaml_reader_test.go
@@ -7,24 +7,40 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// start with "throw an error"
+// Note: Currently only supports the top-level YAML file "eph.yaml"
+// In the future, once/if we allow setting of custom configuration files, we can
+// remove the feature flag logic and also remove the repetitive code in each of
+// these tests.
+
 func TestCanHandleEmptyFile(t *testing.T) {
+	// set the feature flag so we can test additional functionality (do this every test)
+	AllowCustomConfigPath = true
+
 	path := filepath.Join("testdata", "empty.yaml")
 	_, err := readYAMLFile(path)
 	assert.Error(t, err, "expected error when reading an empty file")
+
+	// reset the feature flag (do this every test)
+	AllowCustomConfigPath = false
 }
 
 // also handles files with only comments in them
 func TestCanHandleCommentsOnlyFile(t *testing.T) {
+	AllowCustomConfigPath = true
+
 	path := filepath.Join("testdata", "comments_only.yaml")
 	_, err := readYAMLFile(path)
 	assert.Error(t, err, "expected error when reading a comments-only file")
+
+	AllowCustomConfigPath = false
 }
 
 // also handles:
 // - different types in the yaml
 // - nested yaml
 func TestCanReadYAMLFile(t *testing.T) {
+	AllowCustomConfigPath = true
+
 	path := filepath.Join("testdata", "valid.yaml")
 	data, err := readYAMLFile(path)
 	assert.NoError(t, err)
@@ -46,17 +62,25 @@ func TestCanReadYAMLFile(t *testing.T) {
 	database := yamlMap["database"].(map[string]any)
 	assert.Equal(t, "localhost", database["host"])
 	assert.Equal(t, 1234, database["port"])
+
+	AllowCustomConfigPath = false
 }
 
 // also handles when given a path to a dir rather than a file
+// also handles using the default config file
 func TestThrowsWhenFileDoesNotExist(t *testing.T) {
-	path := filepath.Join("testdata", "nonexistent.yaml")
-	_, err := readYAMLFile(path)
+	// specifically not setting the feature flag here
+
+	_, err := readYAMLFile("blah")
 	assert.Error(t, err)
 }
 
 func TestThrowsWhenFileIsBadYAML(t *testing.T) {
+	AllowCustomConfigPath = true
+
 	path := filepath.Join("testdata", "invalid.yaml")
 	_, err := readYAMLFile(path)
 	assert.Error(t, err)
+
+	AllowCustomConfigPath = false
 }

--- a/internal/config/yaml_reader_test.go
+++ b/internal/config/yaml_reader_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// start with "throw an error"
+func TestCanHandleEmptyFile(t *testing.T) {
+	path := filepath.Join("testdata", "empty.yaml")
+	_, err := readYAMLFile(path)
+	assert.Error(t, err, "expected error when reading an empty file")
+}
+
+// also handles files with only comments in them
+func TestCanHandleCommentsOnlyFile(t *testing.T) {
+	path := filepath.Join("testdata", "comments_only.yaml")
+	_, err := readYAMLFile(path)
+	assert.Error(t, err, "expected error when reading a comments-only file")
+}
+
+// also handles:
+// - different types in the yaml
+// - nested yaml
+func TestCanReadYAMLFile(t *testing.T) {
+	path := filepath.Join("testdata", "valid.yaml")
+	data, err := readYAMLFile(path)
+	assert.NoError(t, err)
+
+	yamlMap := data.(map[string]any)
+
+	assert.Equal(t, "TestData", yamlMap["name"])
+	assert.Equal(t, 1.0, yamlMap["version"])
+	assert.Equal(t, true, yamlMap["enabled"])
+	assert.Equal(t, int(100), yamlMap["max_users"])
+
+	features := yamlMap["features"].(map[string]any)
+	assert.Equal(t, true, features["authentication"])
+	assert.Equal(t, "info", features["logging"].(map[string]any)["level"])
+
+	logging := features["logging"].(map[string]any)
+	assert.ElementsMatch(t, []any{"file", "console"}, logging["destinations"])
+
+	database := yamlMap["database"].(map[string]any)
+	assert.Equal(t, "localhost", database["host"])
+	assert.Equal(t, int(1234), database["port"])
+}
+
+// also handles when given a path to a dir rather than a file
+func TestThrowsWhenFileDoesNotExist(t *testing.T) {
+	path := filepath.Join("testdata", "nonexistent.yaml")
+	_, err := readYAMLFile(path)
+	assert.Error(t, err)
+}
+
+func TestThrowsWhenFileIsBadYAML(t *testing.T) {
+	path := filepath.Join("testdata", "invalid.yaml")
+	_, err := readYAMLFile(path)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Resolves #28 

---

Had a little bit of setup changes / config file changes as well as the actual implementation of the `readYAMLFile` function.

Had to install golangci-lint, and run golangci-lint migrate (that's how .golangci.bck.yml appeared, figured I'd keep it in for now and make sure we don't need the v1 before we delete it)

Added exclusions to golangci-lint and check-yaml for any yaml files in testdata/ directories.

Added a couple of test files in `internal/config/testdata` for test cases written in `yaml_reader_test.go`.

`readYAMLFile` exists in `yaml_reader.go` and is painfully basic. Only caveat is that I decided to start off with an error if the YAML file in question is empty or only has comments in it.